### PR TITLE
Handle Python < 2.7

### DIFF
--- a/dyntftpd/__init__.py
+++ b/dyntftpd/__init__.py
@@ -5,7 +5,11 @@ __version__ = '0.4.1'
 
 # Prevent message "No handlers could be found for logger "dyntftpd"" to be
 # displayed
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+# Degrade on Python < 2.7
+try:
+    logging.getLogger(__name__).addHandler(logging.NullHandler())
+except AttributeError:
+    pass
 
 
 from .server import TFTPServer

--- a/dyntftpd/__init__.py
+++ b/dyntftpd/__init__.py
@@ -1,16 +1,15 @@
-import logging
-
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
 
 __version__ = '0.4.1'
 
 # Prevent message "No handlers could be found for logger "dyntftpd"" to be
 # displayed
-# Degrade on Python < 2.7
-try:
-    logging.getLogger(__name__).addHandler(logging.NullHandler())
-except AttributeError:
-    pass
-
+logging.getLogger(__name__).addHandler(NullHandler())
 
 from .server import TFTPServer
 


### PR DESCRIPTION
Python < 2.7 doesn't have logging.NullHandler, so this is just a fix to degrade gracefully in that case.  I needed it for Python 2.6 on RHEL 6.x.
